### PR TITLE
Update scan result modal: rule table filters and accordion redesign

### DIFF
--- a/9.4.2/nextjs/src/components/repositories/ScanResultModal.tsx
+++ b/9.4.2/nextjs/src/components/repositories/ScanResultModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Badge, Collapse, Input, Modal, Progress, Select, Table, Tag, Typography } from 'antd'
+import { BulbOutlined, CloseCircleOutlined, ToolOutlined } from '@ant-design/icons'
 import { IRecommendation, IRuleResult, IScanResult, ScanResultModalProps } from '@/Types/Scan/Types'
 import { useStyles } from './styles/ScanResultModal.style'
 
@@ -77,7 +78,14 @@ const ScanResultModal = ({ scanResult, onClose }: ScanResultModalProps) => {
 
   const recItems = scanResult.recommendations.map((rec: IRecommendation, i) => ({
     key: String(i),
-    label: <span className={styles.recCollapseLabel}>{ruleNameMap[rec.ruleId] ?? rec.ruleId}</span>,
+    label: (
+      <span className={styles.recCollapseLabel}>
+        {ruleNameMap[rec.ruleId] ?? rec.ruleId}
+        <span className={styles.recFailBadge}>
+          <CloseCircleOutlined /> Failed
+        </span>
+      </span>
+    ),
     children: <RecommendationBody rec={rec} />,
   }))
 
@@ -217,7 +225,10 @@ const ScanResultBody = ({
       {recItems.length > 0 && (
         <>
           <Title className={styles.sectionTitle}>AI Recommendations</Title>
-          <Collapse items={recItems as Parameters<typeof Collapse>[0]['items']} size="small" />
+          <Collapse
+            items={recItems as Parameters<typeof Collapse>[0]['items']}
+            className={styles.recCollapse}
+          />
         </>
       )}
     </>
@@ -226,14 +237,39 @@ const ScanResultBody = ({
 
 const RecommendationBody = ({ rec }: { rec: IRecommendation }) => {
   const { styles } = useStyles()
+
+  const sections = [
+    {
+      label: 'Issue',
+      text: rec.issueDescription,
+      icon: <CloseCircleOutlined style={{ color: '#ef4444', fontSize: 14 }} />,
+      iconClass: `${styles.recIconWrap} ${styles.recIconIssue}`,
+    },
+    {
+      label: 'Explanation',
+      text: rec.explanation,
+      icon: <BulbOutlined style={{ color: '#3b82f6', fontSize: 14 }} />,
+      iconClass: `${styles.recIconWrap} ${styles.recIconExplanation}`,
+    },
+    {
+      label: 'Suggested Fix',
+      text: rec.suggestedFix,
+      icon: <ToolOutlined style={{ color: '#10b981', fontSize: 14 }} />,
+      iconClass: `${styles.recIconWrap} ${styles.recIconFix}`,
+    },
+  ]
+
   return (
-    <div className={styles.recommendationCard}>
-      <div className={styles.recLabel}>Issue</div>
-      <Paragraph className={styles.recText}>{rec.issueDescription}</Paragraph>
-      <div className={styles.recLabel}>Explanation</div>
-      <Paragraph className={styles.recText}>{rec.explanation}</Paragraph>
-      <div className={styles.recLabel}>Suggested Fix</div>
-      <Paragraph className={styles.recText}>{rec.suggestedFix}</Paragraph>
-    </div>
+    <>
+      {sections.map((s) => (
+        <div key={s.label} className={styles.recSection}>
+          <div className={s.iconClass}>{s.icon}</div>
+          <div className={styles.recSectionContent}>
+            <Text className={styles.recSectionLabel}>{s.label}</Text>
+            <Paragraph className={styles.recSectionText}>{s.text}</Paragraph>
+          </div>
+        </div>
+      ))}
+    </>
   )
 }

--- a/9.4.2/nextjs/src/components/repositories/styles/ScanResultModal.style.ts
+++ b/9.4.2/nextjs/src/components/repositories/styles/ScanResultModal.style.ts
@@ -141,28 +141,89 @@ export const useStyles = createStyles(({ css }) => ({
     font-size: 13px !important;
     color: #6b7280 !important;
   `,
+  recCollapse: css`
+    border: none !important;
+    background: transparent !important;
+
+    .ant-collapse-item {
+      border: 1px solid #e5e7eb !important;
+      border-radius: 10px !important;
+      margin-bottom: 8px !important;
+      overflow: hidden;
+    }
+
+    .ant-collapse-item:last-child {
+      border-radius: 10px !important;
+    }
+
+    .ant-collapse-header {
+      background: #fef2f2 !important;
+      border-left: 4px solid #ef4444 !important;
+      padding: 12px 16px !important;
+      align-items: center !important;
+    }
+
+    .ant-collapse-content {
+      border-top: 1px solid #e5e7eb !important;
+    }
+
+    .ant-collapse-content-box {
+      padding: 0 !important;
+    }
+  `,
   recCollapseLabel: css`
     font-weight: 600;
     font-size: 14px;
+    color: #111827;
   `,
-  recommendationCard: css`
-    background: #f9fafb;
-    border-radius: 10px;
-    padding: 16px;
-    margin-bottom: 8px;
+  recFailBadge: css`
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #ef4444;
+    margin-left: 8px;
   `,
-  recLabel: css`
-    font-size: 11px;
-    font-weight: 700;
-    color: #9ca3af;
+  recSection: css`
+    display: flex;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid #f3f4f6;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  `,
+  recIconWrap: css`
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-top: 1px;
+  `,
+  recIconIssue: css`background: #fef2f2;`,
+  recIconExplanation: css`background: #eff6ff;`,
+  recIconFix: css`background: #f0fdf4;`,
+  recSectionContent: css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  `,
+  recSectionLabel: css`
+    font-size: 11px !important;
+    font-weight: 700 !important;
+    color: #9ca3af !important;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin-top: 8px;
-    margin-bottom: 2px;
+    margin: 0 !important;
   `,
-  recText: css`
+  recSectionText: css`
     font-size: 13px !important;
     color: #374151 !important;
-    margin-bottom: 0 !important;
+    margin: 0 !important;
   `,
 }))


### PR DESCRIPTION
## Summary

- Closes #61 — Add search, category filter, status filter, and default pagination (5 rows) to the Rule Results table in the scan result modal. Failed rules sort to the top.
- Closes #62 — Redesign AI recommendations accordion: red left-border header with Failed badge, icon-labelled sections (Issue, Explanation, Suggested Fix) with coloured icon bubbles and dividers.

## Test plan

- [ ] Rule Results table defaults to 5 rows per page with a size changer
- [ ] Searching by rule name or rule ID filters the table correctly
- [ ] Category filter narrows results to the selected category
- [ ] Status filter shows only passed or failed rules
- [ ] Failed rules always appear before passed rules
- [ ] Each AI recommendation accordion header shows the rule name and a red "Failed" badge
- [ ] Expanding an accordion item shows Issue, Explanation, and Suggested Fix sections with correct icons and colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)