### PR TITLE
fix: preserve tenant ID query param in abpApiForTenant

### DIFF
--- a/9.4.2/nextjs/src/lib/abp.ts
+++ b/9.4.2/nextjs/src/lib/abp.ts
@@ -9,7 +9,7 @@ const DEFAULT_TENANT_ID = 1
 // tenant resolver runs.
 const withTenantParam = (instance: AxiosInstance): AxiosInstance => {
   instance.interceptors.request.use((config) => {
-    config.params = { ...config.params, 'Abp.TenantId': DEFAULT_TENANT_ID }
+    config.params = { 'Abp.TenantId': DEFAULT_TENANT_ID, ...config.params }
     return config
   })
   return instance


### PR DESCRIPTION
withTenantParam spread order was wrong — it overwrote the instance-level Abp.TenantId param with DEFAULT_TENANT_ID (1). On Render the dot-header is stripped, so the backend fell back to the query param and authenticated against the wrong tenant, returning "Login failed!".